### PR TITLE
Pandoc template for use with revquantum

### DIFF
--- a/pandoc/example.bib
+++ b/pandoc/example.bib
@@ -1,0 +1,8 @@
+@article{aloupis_classic_2012,
+    title = {Classic {N}intendo Games are (Computationally) Hard},
+    url = {http://arxiv.org/abs/1203.1895},
+    journal = {arXiv:1203.1895},
+    author = {Aloupis, Greg and Demaine, Erik D and Guo, Alan and Viglietta, Giovanni},
+    month = mar,
+    year = {2012}
+}

--- a/pandoc/example.md
+++ b/pandoc/example.md
@@ -1,0 +1,23 @@
+---
+title: Pandoc Example 
+author: Christopher Granade
+date: 16 November 2015
+bibliography: example.bib
+pretty: true
+...
+
+# Test Section #
+
+This is an example section, demonstrating a few different ``revquantum``
+features working in Markdown. For instance, familiar math-mode commands like $\Tr$ and $\id$ work.
+
+# Those BibTeX Hacks #
+
+The BibTeX hacks work, too, so that we can happily cite our favorite papers like @aloupis_classic_2012. We have to compile on our own, though. For example:
+
+```
+$ pandoc --natbib --filter pandoc-citeproc --template=revquantum example.md -o example.tex --standalone
+$ latexmk --pdf example.tex
+```
+
+This is currently a pain point, but hopefully should be fixed in future versions.

--- a/pandoc/install.py
+++ b/pandoc/install.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import os, sys, shutil
+
+MANIFEST = [
+    'templates/revquantum.latex'
+]
+
+DIR_STRUCTURE = set([''] + [
+    os.path.dirname(filename)
+    for filename in MANIFEST
+])
+
+if __name__ == "__main__":
+    # Find what OS we're running on and use that to define
+    # the data-dir for Pandoc.
+    data_dir = os.path.expanduser(
+        os.path.join("~", ".pandoc")
+        if sys.platform in ('linux2', 'darwin', 'cygwin')
+        else
+        os.path.join("~", "AppData", "Roaming", "pandoc")
+        if sys.platform in ('win32', )
+        else
+        None
+    )
+
+    # Ensure that the directory structure exists.
+    for dirname in DIR_STRUCTURE:
+        try:
+            os.makedirs(os.path.join(data_dir, dirname))
+            print("Created {}".format(os.path.join(data_dir, dirname)))
+        except:
+            pass
+
+    for filename in MANIFEST:
+        src = os.path.join(os.path.dirname(__file__), filename)
+        dest = os.path.join(data_dir, filename)
+        print("{} → {}".format(filename, dest))
+        shutil.copyfile(
+            src, dest
+        )
+
+    print(
+        "\n"
+        "Pandoc template installed sucessfully. To use the new template, run "
+        "with the '--template=revquantum' option."
+        "\n"
+    )

--- a/pandoc/templates/LICENSE.md
+++ b/pandoc/templates/LICENSE.md
@@ -1,0 +1,40 @@
+[Pandoc](http://github.com/jgm/pandoc) template for use with revquantum, modified from the default LaTeX template available from the [pandoc-templates](https://github.com/jgm/pandoc-templates) project.
+
+Largely this fork consists of stripping features that are incompatible with or obviated by revquantum and moving document metadata to a location compatible with revtex4-1. In the future, this template will hopefully support options for controlling revtex features such as ``onecolumn`` versus ``twocolumn``.
+
+As per the pandoc-templates license, this template is dual licensed, under both
+the GPL (v2 or higher, same as pandoc) and the BSD 3-clause license
+(included below).
+
+----
+
+Copyright (c) 2014, John MacFarlane
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of John MacFarlane nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pandoc/templates/revquantum.latex
+++ b/pandoc/templates/revquantum.latex
@@ -1,0 +1,164 @@
+\documentclass[pra,aps,onecolumn,superscriptaddress,10pt,notitlepage$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{revtex4-1}
+\usepackage[pretty$if(listings)$,uselistings$endif$]{revquantum}
+\usepackage{ifxetex,ifluatex}
+\usepackage{fixltx2e} % provides \textsubscript
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
+  \usepackage[utf8]{inputenc}
+$if(euro)$
+  \usepackage{eurosym}
+$endif$
+\else % if luatex or xelatex
+  \ifxetex
+    \usepackage{mathspec}
+  \else
+    \usepackage{fontspec}
+  \fi
+  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+  \newcommand{\euro}{€}
+\fi
+% use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+$if(geometry)$
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
+\hypersetup{unicode=true,
+$if(title-meta)$
+            pdftitle={$title-meta$},
+$endif$
+$if(author-meta)$
+            pdfauthor={$author-meta$},
+$endif$
+$if(subtitle)$
+            pdfsubject={$subtitle$},
+$endif$
+$if(keywords)$
+            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+$endif$
+            breaklinks=true}
+\urlstyle{same}  % don't use monospace font for urls
+$if(lhs)$
+\lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
+$endif$
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
+$if(verbatim-in-note)$
+\usepackage{fancyvrb}
+\VerbatimFootnotes % allows verbatim text in footnotes
+$endif$
+$if(tables)$
+\usepackage{longtable,booktabs}
+$endif$
+$if(graphics)$
+\usepackage{graphicx,grffile}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+$endif$
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\renewcommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+$if(strikeout)$
+\usepackage[normalem]{ulem}
+% avoid problems with \sout in headers with hyperref:
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+$endif$
+$if(indent)$
+$else$
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt plus 2pt minus 1pt}
+$endif$
+\setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+$if(numbersections)$
+\setcounter{secnumdepth}{5}
+$else$
+\setcounter{secnumdepth}{0}
+$endif$
+
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+$if(subparagraph)$
+$else$
+% Redefines (sub)paragraphs to behave more like sections
+\ifx\paragraph\undefined\else
+\let\oldparagraph\paragraph
+\renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
+\let\oldsubparagraph\subparagraph
+\renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
+$endif$
+
+\begin{document}
+$if(title)$
+\title{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
+$endif$
+$if(author)$
+\author{$for(author)$$author$$sep$ \and $endfor$}
+$endif$
+\date{$date$}
+
+$if(title)$
+\maketitle
+$endif$
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+{
+$if(colorlinks)$
+\hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
+$endif$
+\setcounter{tocdepth}{$toc-depth$}
+\tableofcontents
+}
+$endif$
+$if(lot)$
+\listoftables
+$endif$
+$if(lof)$
+\listoffigures
+$endif$
+$body$
+
+$if(natbib)$
+$if(bibliography)$
+$if(biblio-title)$
+$if(book-class)$
+\renewcommand\bibname{$biblio-title$}
+$else$
+\renewcommand\refname{$biblio-title$}
+$endif$
+$endif$
+\bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+
+$endif$
+$endif$
+$if(biblatex)$
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+
+$endif$
+$for(include-after)$
+$include-after$
+
+$endfor$
+\end{document}

--- a/pandoc/templates/revquantum.latex
+++ b/pandoc/templates/revquantum.latex
@@ -1,5 +1,10 @@
 \documentclass[pra,aps,onecolumn,superscriptaddress,10pt,notitlepage$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{revtex4-1}
-\usepackage[pretty$if(listings)$,uselistings$endif$]{revquantum}
+\usepackage[$if(pretty)$pretty$endif$,$if(listings)$,uselistings$endif$]{revquantum}
+
+% Fake natbib support to get BibTeX working through {revtex4-1}
+% instead.
+\renewcommand{\citet}{\cite}
+
 \usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex


### PR DESCRIPTION
This PR adds a new Pandoc template that can be used to quickly write revquantum articles, ideal for notes and other one-off documents.
